### PR TITLE
fix: close policy grant gaps for all 42 tools

### DIFF
--- a/dhall/policies/fragments/campaign-runner.dhall
+++ b/dhall/policies/fragments/campaign-runner.dhall
@@ -9,6 +9,7 @@ let grants
     = [ { src = agents.campaign_runner
         , dst = ns.external
         , app = [ tools.port_scan
+                , tools.network_posture
                 , tools.tls_check
                 , tools.subdomain_enum
                 , tools.dns_recon
@@ -16,6 +17,8 @@ let grants
                 , tools.target_profile
                 , tools.credential_scan
                 , tools.vuln_scan
+                , tools.api_fuzz
+                , tools.cve_monitor
                 ]
         , parameter_constraints = [] : List { mapKey : Text, mapValue : Text }
         , rate_limit = 30

--- a/dhall/policies/fragments/hexstrike-agent.dhall
+++ b/dhall/policies/fragments/hexstrike-agent.dhall
@@ -8,21 +8,61 @@ let grants
     : List Grant
     = [ { src = agents.hexstrike_agent
         , dst = ns.any
-        , app = [ tools.port_scan
+        , app = [ -- NetworkRecon
+                  tools.port_scan
                 , tools.host_discovery
+                , tools.nmap_scan
+                , tools.network_posture
+                  -- DNSRecon
                 , tools.subdomain_enum
                 , tools.dns_recon
+                  -- CryptoAnalysis
                 , tools.tls_check
+                  -- CredentialAudit
                 , tools.credential_scan
+                , tools.sops_rotation_check
+                , tools.brute_force
+                , tools.hash_crack
+                  -- WebSecurity
+                , tools.dir_discovery
+                , tools.vuln_scan
+                , tools.sqli_test
+                , tools.xss_test
+                , tools.waf_detect
+                , tools.web_crawl
+                  -- APITesting
+                , tools.api_fuzz
+                , tools.graphql_scan
+                , tools.jwt_analyze
+                  -- SMBEnum
+                , tools.smb_enum
+                , tools.network_exec
+                , tools.rpc_enum
+                  -- CloudSecurity
+                , tools.cloud_posture
+                , tools.container_scan
+                , tools.iac_scan
+                , tools.k8s_audit
+                  -- BinaryAnalysis
+                , tools.disassemble
+                , tools.debug
+                , tools.gadget_search
+                , tools.firmware_analyze
+                  -- Forensics
+                , tools.memory_forensics
+                , tools.file_carving
+                , tools.steganography
+                , tools.metadata_extract
+                  -- Intelligence
+                , tools.cve_monitor
+                , tools.exploit_gen
+                , tools.threat_correlate
+                  -- Orchestration
                 , tools.smart_scan
                 , tools.target_profile
+                  -- Meta
                 , tools.server_health
                 , tools.execute_command
-                , tools.vuln_scan
-                , tools.dir_discovery
-                , tools.web_crawl
-                , tools.container_scan
-                , tools.k8s_audit
                 ]
         , parameter_constraints = [] : List { mapKey : Text, mapValue : Text }
         , rate_limit = 60


### PR DESCRIPTION
## Summary
- **hexstrike-agent**: 16 tools were missing from grants — added all WebSecurity, CredentialAudit, SMBEnum, BinaryAnalysis, and Forensics domains
- **campaign-runner**: added `network_posture`, `api_fuzz`, `cve_monitor`
- New `TestPolicyCoverage` in Go verifies all 42 tools are grantable to hexstrike-agent

### Tools added to hexstrike-agent
`network_posture`, `sops_rotation_check`, `brute_force`, `hash_crack`, `sqli_test`, `xss_test`, `waf_detect`, `api_fuzz`, `graphql_scan`, `jwt_analyze`, `smb_enum`, `network_exec`, `rpc_enum`, `cloud_posture`, `iac_scan`, `disassemble`, `debug`, `gadget_search`, `firmware_analyze`, `memory_forensics`, `file_carving`, `steganography`, `metadata_extract`, `cve_monitor`, `exploit_gen`, `threat_correlate`

### Tools added to campaign-runner
`network_posture`, `api_fuzz`, `cve_monitor`

## Test plan
- [x] `dhall-check` + `dhall-validate` pass
- [x] Go `TestPolicyCoverage` passes (all 42 tools covered)
- [x] Full Go test suite passes (29 tests)
- [ ] CI green