### PR TITLE
fix(fstar): remove deprecated --verify_module flag

### DIFF
--- a/fstar/Makefile
+++ b/fstar/Makefile
@@ -16,10 +16,10 @@ extract: verify $(EXTRACTED)
 	@echo ":: F* -> OCaml extraction complete"
 
 cache/%.fst.checked: %.fst | cache
-	$(FSTAR) $(FSTAR_FLAGS) --verify_module $(basename $<) $<
+	$(FSTAR) $(FSTAR_FLAGS) $<
 
 out/Hexstrike_%.ml: Hexstrike.%.fst | out
-	$(FSTAR) $(FSTAR_FLAGS) --codegen OCaml --extract_module Hexstrike.$(word 2,$(subst ., ,$<)) $<
+	$(FSTAR) $(FSTAR_FLAGS) --codegen OCaml $<
 
 cache:
 	mkdir -p cache


### PR DESCRIPTION
## Summary

- F* 2025.12.15 (current nixpkgs) removed `--verify_module` and `--extract_module` flags
- Modern F* verifies files passed on the command line directly; dependencies are lax-checked automatically
- Extraction uses `--codegen OCaml file.fst` which extracts all impl files in the dep graph

This should fix the F* verification and extraction CI jobs (currently `continue-on-error: true`).

## Test plan

- [x] CI F* jobs should now pass instead of failing with `unrecognized option '--verify_module'`